### PR TITLE
setup devenv, a little bit of hello-worlding

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,5 @@
+export DIRENV_WARN_TIMEOUT=20s
+
+eval "$(devenv direnvrc)"
+
+use devenv

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,13 @@ go.work.sum
 
 # env file
 .env
+
+# Devenv
+.devenv*
+devenv.local.nix
+
+# direnv
+.direnv
+
+# pre-commit
+.pre-commit-config.yaml

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+run:
+	go run cmd/mdma/main.go

--- a/cmd/mdma/main.go
+++ b/cmd/mdma/main.go
@@ -1,0 +1,12 @@
+package main
+
+import "fmt"
+import "github.com/bradstewart/mdma/internal/hello"
+
+func main() {
+
+  person := hello.NewPerson("Jason", 42)
+
+  fmt.Println("Hello DJ")
+  fmt.Println(person.Greet())
+}

--- a/devenv.lock
+++ b/devenv.lock
@@ -1,0 +1,103 @@
+{
+  "nodes": {
+    "devenv": {
+      "locked": {
+        "dir": "src/modules",
+        "lastModified": 1744895150,
+        "owner": "cachix",
+        "repo": "devenv",
+        "rev": "cc0e0717f9f2d4b614d5e80fd6d25ba96f98bf2e",
+        "type": "github"
+      },
+      "original": {
+        "dir": "src/modules",
+        "owner": "cachix",
+        "repo": "devenv",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1733328505,
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "ff81ac966bb2cae68946d5ed5fc4994f96d0ffec",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "git-hooks": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "gitignore": "gitignore",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1742649964,
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "rev": "dcf5072734cb576d2b0c59b2ac44f5050b5eac82",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "git-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1709087332,
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1733477122,
+        "owner": "cachix",
+        "repo": "devenv-nixpkgs",
+        "rev": "7bd9e84d0452f6d2e63b6e6da29fe73fac951857",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "ref": "rolling",
+        "repo": "devenv-nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "devenv": "devenv",
+        "git-hooks": "git-hooks",
+        "nixpkgs": "nixpkgs",
+        "pre-commit-hooks": [
+          "git-hooks"
+        ]
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/devenv.nix
+++ b/devenv.nix
@@ -1,0 +1,34 @@
+{ pkgs, lib, config, inputs, ... }:
+
+{
+  env.GREET = "devenv";
+
+  packages = [ pkgs.git ];
+  languages.go.enable = true;
+
+  # scripts.hello.exec = ''
+  #   echo hello from $GREET
+  # '';
+  #
+  # enterShell = ''
+  #   hello
+  #   git --version
+  # '';
+
+  # https://devenv.sh/tasks/
+  # tasks = {
+  #   "myproj:setup".exec = "mytool build";
+  #   "devenv:enterShell".after = [ "myproj:setup" ];
+  # };
+
+  # https://devenv.sh/tests/
+  # enterTest = ''
+  #   echo "Running tests"
+  #   git --version | grep --color=auto "${pkgs.git.version}"
+  # '';
+
+  # https://devenv.sh/git-hooks/
+  # git-hooks.hooks.shellcheck.enable = true;
+
+  # See full reference at https://devenv.sh/reference/options/
+}

--- a/devenv.yaml
+++ b/devenv.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://devenv.sh/devenv.schema.json
+inputs:
+  nixpkgs:
+    url: github:cachix/devenv-nixpkgs/rolling
+
+# If you're using non-OSS software, you can set allowUnfree to true.
+# allowUnfree: true
+
+# If you're willing to use a package that's vulnerable
+# permittedInsecurePackages:
+#  - "openssl-1.1.1w"
+
+# If you have more than one devenv you can merge them
+#imports:
+# - ./backend

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/bradstewart/mdma
+
+go 1.23.3

--- a/internal/hello/hello.go
+++ b/internal/hello/hello.go
@@ -1,0 +1,27 @@
+package hello
+import "fmt"
+
+// lowercase is unexported (private)
+type info struct {
+  name string
+  age int8
+}
+
+// this is exported
+type Person struct {
+  Info info
+  // Person.Info.name and age are private
+}
+
+func NewPerson(name string, age int8) Person {
+  return Person{
+    Info: info{
+      name: name,
+      age: age,
+    },
+  }
+}
+
+func (p Person) Greet() string {
+  return fmt.Sprintf("Hello, %s. You are %d", p.Info.name, p.Info.age)
+}


### PR DESCRIPTION
Adds a golang devenv config, which wires up an isolated Go environment (for nix/devenv users). The changes will not affect any non-nix/devenv users.

Also a little bit of hello world stuff and super basic project structure beginnings.

Requirements for the devenv magic:
- [nix](https://nixos.org/download/) 
- [devenv](https://devenv.sh/getting-started/)

Recommendations:
- use [nix home manager (standalone)](https://nix-community.github.io/home-manager/index.xhtml#sec-install-standalone) to install devenv:

```nix
home.packages = [
    pkgs.devenv
]
```